### PR TITLE
chore: rename app title from `JAM` to `Jam`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Wrapper for JAM
+# Wrapper for Jam
 
-JAM is a web UI for JoinMarket with focus on user-friendliness. It aims to provide sensible defaults and be easy to use for beginners while still providing the features advanced users expect.
+Jam is a web UI for JoinMarket with focus on user-friendliness. It aims to provide sensible defaults and be easy to use for beginners while still providing the features advanced users expect.
 
 ## Dependencies
 
@@ -124,6 +124,6 @@ start-cli package install /path/to/jam.s9pk
 
 ## Verify Install
 
-Go to your StartOS Services page, select JAM and start the service.
+Go to your StartOS Services page, select Jam and start the service.
 
 #Done

--- a/assets/utils/check-api.sh
+++ b/assets/utils/check-api.sh
@@ -2,11 +2,11 @@
 
 DURATION=$(</dev/stdin)
 if (($DURATION <= 5000)); then
-    echo "JAM Web API may take a while to start, please be patient..."
+    echo "Jam Web API may take a while to start, please be patient..."
     exit 60
 else
     if ! curl -SL --silent --fail --insecure --max-time 10 https://jam.embassy:28183/api/v1/session 2>/dev/null; then
-        echo "JAM API is unreachable" >&2
+        echo "Jam API is unreachable" >&2
         exit 61
     fi
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -21,14 +21,14 @@ echo "Running on Bitcoin Core..."
   echo '  Username: ' >> /data/start9/stats.yaml
         echo '    type: string' >> /data/start9/stats.yaml
         echo "    value: \"$APP_USER\"" >> /data/start9/stats.yaml
-        echo '    description: This is your username for JAM' >> /data/start9/stats.yaml
+        echo '    description: This is your username for Jam' >> /data/start9/stats.yaml
         echo '    copyable: true' >> /data/start9/stats.yaml
         echo '    masked: false' >> /data/start9/stats.yaml
         echo '    qr: false' >> /data/start9/stats.yaml
   echo '  Password: ' >> /data/start9/stats.yaml
         echo '    type: string' >> /data/start9/stats.yaml
         echo "    value: \"$APP_PASSWORD\"" >> /data/start9/stats.yaml
-        echo '    description: This is your password for JAM. Please use caution when sharing this password, you could lose your funds!' >> /data/start9/stats.yaml
+        echo '    description: This is your password for Jam. Please use caution when sharing this password, you could lose your funds!' >> /data/start9/stats.yaml
         echo '    copyable: true' >> /data/start9/stats.yaml
         echo '    masked: true' >> /data/start9/stats.yaml
         echo '    qr: false' >> /data/start9/stats.yaml

--- a/instructions.md
+++ b/instructions.md
@@ -1,9 +1,9 @@
 ## Usage Instructions
 
-1. Start the JAM service and copy your username and password from Services > JAM > Properties
-2. Open JAM by pressing the `LAUNCH UI` button, authenticating with your username and password.
-3. For the first time using JAM, you will need to setup your wallet credentials. You can set up as many JAM wallets as you like.
-4. Please visit the [JAM Docs Website](https://jamdocs.org/) for detailed documentation on using JAM.
+1. Start the Jam service and copy your username and password from Services > Jam > Properties
+2. Open Jam by pressing the `LAUNCH UI` button, authenticating with your username and password.
+3. For the first time using Jam, you will need to setup your wallet credentials. You can set up as many Jam wallets as you like.
+4. Please visit the [Jam Docs Website](https://jamdocs.org/) for detailed documentation on using Jam.
 
 For additional questions or support, please reach out [on telegram](https://t.me/JoinMarketWebUI).
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,9 +1,9 @@
 id: jam
-title: JAM
+title: Jam
 version: 0.2.0.1
 release-notes: |
-  * Update to latest jam-docker image upstream - [JAM v0.2.0 Release Notes](https://github.com/joinmarket-webui/jam/releases/tag/v0.2.0)
-  * JAM v0.2.0 updates to latest JoinMarket ([v0.9.11](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/release-notes/release-notes-0.9.11.md))
+  * Update to latest jam-docker image upstream - [Jam v0.2.0 Release Notes](https://github.com/joinmarket-webui/jam/releases/tag/v0.2.0)
+  * Jam v0.2.0 updates to latest JoinMarket ([v0.9.11](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/release-notes/release-notes-0.9.11.md))
   * Fix default wallet name regression in jam-startos v0.2.0
 license: MIT
 wrapper-repo: "https://github.com/Start9Labs/jam-wrapper"
@@ -12,7 +12,7 @@ support-site: "https://github.com/joinmarket-webui/jam-docker/issues"
 marketing-site: "https://jamapp.org"
 build: ["make"]
 description:
-  short: JAM - A friendly UI for JoinMarket
+  short: Jam - A friendly UI for JoinMarket
   long: |
     Jam is a web UI for JoinMarket with focus on user-friendliness.
     It aims to provide sensible defaults and be easy to use for beginners while still providing the features advanced users expect.
@@ -30,12 +30,12 @@ main:
     jam: /root/.joinmarket
 health-checks:
   web-ui:
-    name: JAM UI
-    success-message: JAM is ready to visit in a web browser
+    name: Jam UI
+    success-message: Jam is ready to visit in a web browser
     type: script
   api:
-    name: JAM API
-    success-message: The JAM API is accessible and responding
+    name: Jam API
+    success-message: The Jam API is accessible and responding
     type: docker
     image: main
     entrypoint: "check-api.sh"
@@ -58,7 +58,7 @@ volumes:
     type: assets
 interfaces:
   main:
-    name: JAM Web UI
+    name: Jam Web UI
     description: Specifies the interface to listen on for HTTP connections.
     tor-config:
       port-mapping:
@@ -84,9 +84,9 @@ dependencies:
         type: script
 alerts:
   install: |
-    WARNING: If you have an older version of JAM running, this install will stop all active liquidity offers. You will need to manually restart your offers after the install is complete.
+    WARNING: If you have an older version of Jam running, this install will stop all active liquidity offers. You will need to manually restart your offers after the install is complete.
   start: |
-    It may take some time for the JAM API to initialize over the Tor network, please be patient.
+    It may take some time for the Jam API to initialize over the Tor network, please be patient.
 migrations:
   from:
     "*":

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,7 +6,7 @@ release-notes: |
   * Jam v0.2.0 updates to latest JoinMarket ([v0.9.11](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/release-notes/release-notes-0.9.11.md))
   * Fix default wallet name regression in jam-startos v0.2.0
 license: MIT
-wrapper-repo: "https://github.com/Start9Labs/jam-wrapper"
+wrapper-repo: "https://github.com/Start9Labs/jam-startos"
 upstream-repo: "https://github.com/joinmarket-webui/jam-docker"
 support-site: "https://github.com/joinmarket-webui/jam-docker/issues"
 marketing-site: "https://jamapp.org"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,7 +8,7 @@ release-notes: |
 license: MIT
 wrapper-repo: "https://github.com/Start9Labs/jam-startos"
 upstream-repo: "https://github.com/joinmarket-webui/jam-docker"
-support-site: "https://github.com/joinmarket-webui/jam-docker/issues"
+support-site: "https://github.com/joinmarket-webui/jam/issues"
 marketing-site: "https://jamapp.org"
 build: ["make"]
 description:

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -21,8 +21,8 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
   },
   username: {
     type: "string",
-    name: "JAM Username",
-    description: "Administrator username for JAM",
+    name: "Jam Username",
+    description: "Administrator username for Jam",
     nullable: false,
     copyable: true,
     masked: false,
@@ -30,8 +30,8 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
   },
   password: {
     type: "string",
-    name: "JAM Password",
-    description: "Administrator password for JAM",
+    name: "Jam Password",
+    description: "Administrator password for Jam",
     nullable: false,
     copyable: true,
     masked: true,


### PR DESCRIPTION
Renames app title from `JAM` to `Jam`.

The word has been changed on all occurrences where it seems safe to do so.
Only two log messages have been left untouched, as I am not sure if they might be read by a downstream service?
See [`check-api.sh` line 5 and 9](https://github.com/Start9Labs/jam-startos/blob/a2858ffe0a0fa3a52a1cf9b6713e540f0c28203b/assets/utils/check-api.sh#L5) - is it safe to rename it here as well?

Additionally, it changes some URLs in `manifest.yml`:
- `wrapper-repo` from "https://github.com/Start9Labs/jam-wrapper" to "https://github.com/Start9Labs/jam-startos"
- `support-site` from "https://github.com/joinmarket-webui/jam-docker/issues" to "https://github.com/joinmarket-webui/jam/issues"

Hope these changes are also in your interest.
Thank you! :pray: 